### PR TITLE
feat: skip layer destroy

### DIFF
--- a/terraform/layer.tf
+++ b/terraform/layer.tf
@@ -5,6 +5,7 @@ resource "aws_lambda_layer_version" "lambda_layer" {
   source_code_hash = filebase64sha256("layer.zip")
 
   compatible_runtimes = ["python3.9"]
+  skip_destroy        = true
 }
 
 resource "aws_lambda_layer_version_permission" "lambda_layer_permission" {


### PR DESCRIPTION
# Summary
Do not destroy old versions of the lambda layer
when a new version is published.

This is being done to support our projects that
are directly pulling this layer into a Docker image build.

# Related
- #7 