### PR TITLE
chore: changing devcontainer flow to work with arm64

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,63 +4,17 @@
 ARG VARIANT="3.9"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-# Set these in devcontainer.json
-ARG SHELLCHECK_VERSION
-ARG SHELLCHECK_CHECKSUM
-ARG TERRAFORM_VERSION
-ARG TERRAFORM_CHECKSUM
-ARG TERRAGRUNT_VERSION
-ARG TERRAGRUNT_CHECKSUM
-
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     && apt-get autoremove -y && apt-get clean -y
 
-# Install Terraform
-RUN curl -Lo terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
-    && echo "${TERRAFORM_CHECKSUM} terraform.zip" | sha256sum --check \
-    && unzip terraform.zip \
-    && mv terraform /usr/local/bin/ \
-    && rm terraform.zip
-
-# Install Terragrunt
-RUN curl -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v"${TERRAGRUNT_VERSION}"/terragrunt_linux_"$(dpkg --print-architecture)" \
-    && echo "${TERRAGRUNT_CHECKSUM} terragrunt" | sha256sum --check \
-    && chmod +x terragrunt \
-    && mv terragrunt /usr/local/bin/
-
-# Install ShellCheck
-RUN curl -Lo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    && echo "${SHELLCHECK_CHECKSUM} shellcheck.tar.xz" | sha256sum --check \
-    && tar -xf shellcheck.tar.xz \
-    && mv "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/ \
-    && rm -r shellcheck*
-
 # Install Checkov
 RUN pip3 install --upgrade requests setuptools \
     && pip3 install --upgrade botocore checkov
 
-# Install AWS CLI
-ARG AWS_CLI_VERSION
-COPY .devcontainer/aws_cli.asc ./
-RUN curl -Lo awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" \
-    && curl -Lo awscliv2.sig "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip.sig" \
-    && gpg --import ./aws_cli.asc \
-    && gpg --verify awscliv2.sig awscliv2.zip \
-    && unzip awscliv2.zip \
-    && ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
-
-
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-
-# Install Powershell
-RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y powershell
-
 
 COPY .devcontainer/apt-packages.txt ./
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,5 +41,17 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"features": {
+		"ghcr.io/devcontainers/features/aws-cli:1": {
+			"version": "2.2.29"
+		},
+		"ghcr.io/devcontainers/features/powershell:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/terraform:1": {
+			"version": "1.0.3",
+			"terragrunt": "0.31.1"
+		}
+	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,13 +9,6 @@ services:
         VARIANT: "3.9"
         INSTALL_NODE: "true"
         NODE_VERSION: "lts/*"
-        SHELLCHECK_VERSION: "0.7.2"
-        SHELLCHECK_CHECKSUM: "70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188"
-        TERRAFORM_VERSION: "1.0.3"
-        TERRAFORM_CHECKSUM: "99c4866ffc4d3a749671b1f74d37f907eda1d67d7fc29ed5485aeff592980644"
-        TERRAGRUNT_VERSION: "0.31.1"
-        TERRAGRUNT_CHECKSUM: "76b253919ad688025a4a37338e5602543b0426cae1be1f863b4f3d60dd95ac28"
-        AWS_CLI_VERSION: "2.2.29"
     volumes:
       - ..:/workspace:cached   
     command: sleep infinity


### PR DESCRIPTION
# Summary | Résumé

devcontainer is failing to run with arm64 arch. Added terraform, awscli and powershell as features for the devcontainer, abstracting the need to pass architecture for installing them. Spellcheck is part of the vscode extension and there is no need to explicitly provide it as a feature.
