### PR TITLE
feat: publish Docker SBOM and vulnerability scan

### DIFF
--- a/.github/workflows/ci_container_build.yml
+++ b/.github/workflows/ci_container_build.yml
@@ -16,11 +16,3 @@ jobs:
         working-directory: ./layer
         run: |
           docker build -t aws-sentinel-connector:test .
-
-      - name: Generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@4368a5486da1f0bb698ffe717687612d4231c6cd # v1.1.7
-        with:
-          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
-          docker_image: aws-sentinel-connector:test
-          project_name: aws-sentinel-conector-layer/docker
-          project_type: docker

--- a/.github/workflows/ci_container_build_and_push_img.yml
+++ b/.github/workflows/ci_container_build_and_push_img.yml
@@ -12,7 +12,7 @@ env:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -44,9 +44,9 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:$GITHUB_SHA
 
       - name: Generate $REPOSITORY/docker SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@4368a5486da1f0bb698ffe717687612d4231c6cd # v1.1.7
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@a38917b147dfc8f086abcf81529e3c12f26529b8 # v2.1.0
         with:
-          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
-          docker_image: $REGISTRY/$REPOSITORY:$GITHUB_SHA
-          project_name: aws-sentinel-conector-layer/docker
-          project_type: docker
+          docker_image: "${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.GITHUB_SHA }}"
+          dockerfile_path: "layer/Dockerfile"
+          sbom_name: "aws-sentinel-conector-layer"
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -1,0 +1,47 @@
+name: Docker vulnerability scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+env:
+  REPOSITORY: aws-sentinel-connector
+  REGISTRY: public.ecr.aws/cds-snc
+
+permissions:
+  id-token: write
+  security-events: write
+
+jobs:
+  docker-vulnerability-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::283582579564:role/aws-sentinel-connector-layer-apply
+          role-session-name: SentinelGitHubActions
+          aws-region: "us-east-1"
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
+        with:
+          registry-type: public
+
+      - name: Get latest Docker image tag
+        run: |
+          IMAGE_TAG="$(aws ecr-public describe-images --output json --repository-name aws-sentinel-connector --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' | jq . --raw-output)"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
+      - name: Docker vulnerability scan
+        uses: cds-snc/security-tools/.github/actions/docker-scan@a38917b147dfc8f086abcf81529e3c12f26529b8 # v2.1.0
+        with:
+          docker_image: "${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}"
+          dockerfile_path: "layer/Dockerfile"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
# Summary
Update the Generate SBOM action to publish the Docker SBOM to GitHub.

Add a nightly Docker vulnerability scan to publish findings to GitHub.

# Related
- cds-snc/platform-core-services#204