### PR TITLE
Feat/split cq tables

### DIFF
--- a/layer/connector.py
+++ b/layer/connector.py
@@ -96,9 +96,8 @@ def handle_log(event):
             # CloudQuery log
             if "cloudquery" in record["s3"]["object"]["key"]:
                 lines = parse_cloudquery(rawbody)
-                table = {"metadata_table": record["s3"]["object"]["key"].split("/")[1]}
-                lines = [dict(line, **table) for line in lines]
-                log_type = "CloudQuery"
+                log_type = f"CloudQuery_{record['s3']['object']['key'].split('/')[1]}"
+
             if lines:
                 log.info(f"Posting {len(lines)} lines")
                 post_data(customer_id, shared_key, json.dumps(lines), log_type)

--- a/layer/tests/test_connector.py
+++ b/layer/tests/test_connector.py
@@ -322,7 +322,9 @@ def test_handle_log_succeeds_with_cloudquery_log(mock_post_data, mock_io, mock_b
     mock_post_data.return_value = True
     assert connector.handle_log(event) is True
     assert mock_post_data.call_count == 1
-    mock_post_data.assert_called_with('foo', 'foo', ANY, 'CloudQuery_aws_ecr_repositories')
+    mock_post_data.assert_called_with(
+        "foo", "foo", ANY, "CloudQuery_aws_ecr_repositories"
+    )
 
 
 @patch.dict(

--- a/layer/tests/test_connector.py
+++ b/layer/tests/test_connector.py
@@ -2,13 +2,8 @@ import io
 import os
 import pytest
 import connector
-import logzero
-import json
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
-
-logzero.json()
-log = logzero.logger
 
 customer_id = "customer_id"
 log_type = "log_type"
@@ -327,8 +322,7 @@ def test_handle_log_succeeds_with_cloudquery_log(mock_post_data, mock_io, mock_b
     mock_post_data.return_value = True
     assert connector.handle_log(event) is True
     assert mock_post_data.call_count == 1
-    for each in json.loads(mock_post_data.call_args[0][2]):
-        assert each["metadata_table"] == "aws_ecr_repositories"
+    mock_post_data.assert_called_with('foo', 'foo', ANY, 'CloudQuery_aws_ecr_repositories')
 
 
 @patch.dict(


### PR DESCRIPTION
# Summary | Résumé

Save each different CQ AWS Source tables to their respective log types tables