### PR TITLE
feat: add IAM role to list lambda layer versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,36 +5,40 @@
 	"image": "mcr.microsoft.com/vscode/devcontainers/python:3@sha256:6df2043e0cc9f73751c605aa101aafdd74b7b1cc52b7510b729f085e21ade8cd",
 	"workspaceFolder": "/workspaces/aws-sentinel-connector-layer/",
 	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"python.pythonPath": "/usr/local/bin/python",
-		"python.languageServer": "Pylance",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-		"[python]": {
-			"editor.formatOnSave": true
-		},
-		"[terraform]": {
-			"editor.formatOnSave": true
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.pythonPath": "/usr/local/bin/python",
+				"python.languageServer": "Pylance",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+				"[python]": {
+					"editor.formatOnSave": true
+				},
+				"[terraform]": {
+					"editor.formatOnSave": true
+				}
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"redhat.vscode-yaml",
+				"timonwong.shellcheck",
+				"hashicorp.terraform",
+				"github.copilot"
+			]
 		}
 	},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"redhat.vscode-yaml",
-		"timonwong.shellcheck",
-		"hashicorp.terraform",
-		"github.copilot"
-	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,52 @@
+resource "aws_iam_role" "lambda_list_layers" {
+  name               = "lambda-list-layers"
+  assume_role_policy = data.aws_iam_policy_document.lambda_list_layers_assume.json
+}
+
+resource "aws_iam_policy" "lambda_list_layers" {
+  name        = "lambda-list-layers"
+  description = "Policy to allow listing Lambda layers and versions"
+  policy      = data.aws_iam_policy_document.lambda_list_layers.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_list_layers" {
+  role       = aws_iam_role.lambda_list_layers.name
+  policy_arn = aws_iam_policy.lambda_list_layers.arn
+}
+
+data "aws_iam_policy_document" "lambda_list_layers_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::239043911459:role/notification-terraform-apply",
+        "arn:aws:iam::239043911459:role/notification-terraform-plan",
+        "arn:aws:iam::296255494825:role/notification-terraform-apply",
+        "arn:aws:iam::296255494825:role/notification-terraform-plan",
+        "arn:aws:iam::800095993820:role/notification-terraform-apply",
+        "arn:aws:iam::800095993820:role/notification-terraform-plan",
+        "arn:aws:iam::891376947407:role/notification-terraform-apply",
+        "arn:aws:iam::891376947407:role/notification-terraform-plan",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "lambda_list_layers" {
+  statement {
+    sid    = "ListLayers"
+    effect = "Allow"
+    actions = [
+      "lambda:GetFunction",
+      "lambda:ListLayers",
+      "lambda:ListLayerVersions"
+    ]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
# Summary 
Add an IAM role that can be used to list the Lambda layer versions.  This can be used during TF operations to dynamically use the latest available Sentinel Connector Lambda layer.

Also updates the devcontainer to use the new nested property for VS Code customizations.

# Related
- https://github.com/cds-snc/platform-core-services/issues/615