### PR TITLE
fix: remove unnecessary IAM action

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -40,7 +40,6 @@ data "aws_iam_policy_document" "lambda_list_layers" {
     sid    = "ListLayers"
     effect = "Allow"
     actions = [
-      "lambda:GetFunction",
       "lambda:ListLayers",
       "lambda:ListLayerVersions"
     ]


### PR DESCRIPTION
# Summary
Remove the GetFunction action as it is not required to list the lambda layer versions.

# Related
- https://github.com/cds-snc/platform-core-services/issues/615