### PR TITLE
feat: add the v2 Logs Ingestion sink alongside v1 (Phase 2 B2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,54 @@ silently overwrite each other.
 You will need to add your Log Analytics Workspace Customer ID and Shared Key. AWS logs are automatically assigned a LogType.
 Custom application logs are given the log type defined through the `var.log_type`. They also need to be nested inside a json
 object with the key, `application_log`. ex: `{'application_log': {'foo': 'bar'}}` for the layer code to forward it to Azure Sentinel.
+
+### Two ingestion APIs in one layer version
+
+Microsoft is retiring the Data Collector API. This layer supports both it and its replacement, the
+Logs Ingestion API, and **picks between them from the environment variables the Lambda carries** —
+so consumers can migrate one at a time instead of all at once.
+
+| | v1 — Data Collector API | v2 — Logs Ingestion API |
+| --- | --- | --- |
+| Selected when | `DCE_ENDPOINT` / `DCR_CONFIG` are absent | **both** `DCE_ENDPOINT` and `DCR_CONFIG` are set |
+| Config | `CUSTOMER_ID`, `SHARED_KEY` | `DCE_ENDPOINT`, `DCR_CONFIG`, plus Azure credentials |
+| Auth | SharedKey HMAC | Entra, via `DefaultAzureCredential` |
+| Destination | `<LogType>_CL`, workspace-wide | a DCR stream, per log type |
+
+`DCR_CONFIG` is one JSON object mapping a log type to the DCR that accepts it. Populate it from the
+`aws_dcr_config` Terraform output rather than by hand:
+
+```json
+{
+  "AWSSecurityHub":   { "dcrImmutableId": "dcr-…", "streamName": "Custom-AWSSecurityHub_v2_Input" },
+  "AWSCloudWatchLog": { "dcrImmutableId": "dcr-…", "streamName": "Custom-AWSCloudWatchLog_v2_Input" }
+}
+```
+
+#### v2 authentication
+
+Two flows, chosen by which variables are set. **A client secret wins when one is present**, so a
+consumer can move to v2 with a secret first and to federation later without a code change.
+
+| | Client secret | Cognito federation (no stored secret) |
+| --- | --- | --- |
+| Variables | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `COGNITO_IDENTITY_POOL_ID`, `COGNITO_DEVELOPER_PROVIDER_NAME` |
+| Credential | `DefaultAzureCredential` | `ClientAssertionCredential` |
+
+Under federation the Lambda's IAM role is the only credential. It calls
+`cognito-identity:GetOpenIdTokenForDeveloperIdentity`, and the resulting OIDC JWT is presented to
+Entra as a client assertion for a user-assigned managed identity whose federated credential trusts
+`https://cognito-identity.amazonaws.com`. `AZURE_CLIENT_ID` doubles as the Cognito developer user
+identifier, which keeps the `IdentityId` — the federated credential's subject — stable.
+
+The token is fetched through a callable that runs on every credential refresh, never cached: a
+Cognito token is valid for 15 minutes by default while the Entra token lasts about an hour, so an
+assertion minted once at cold start would be stale by the first refresh on a warm container.
+
+With neither flow configured, `DefaultAzureCredential` falls through to its remaining credential
+types, and none of them authenticate inside a Lambda — the failure surfaces at token acquisition on
+the first upload, not when the client is built.
+
+Setting neither `DCE_ENDPOINT` nor `DCR_CONFIG` leaves a Lambda on v1, behaving exactly as before.
+The Azure SDK is imported inside the v2 path, not at module scope, so the layer still loads and
+forwards on v1 in a package set that has no `azure-*` installed.

--- a/layer/connector.py
+++ b/layer/connector.py
@@ -11,39 +11,231 @@ import requests
 logzero.json()
 log = logzero.logger
 
+# LogsIngestionClient built on the first v2 delivery and reused across warm
+# invocations. Building it costs a token acquisition, so this is not free.
+_client = None
+
 
 def handle_log(event):
+    if not config_present():
+        return False
+
+    # SecurityHub events from EventBridge
+    if "source" in event and event["source"] == "aws.securityhub":
+        return deliver(event["detail"]["findings"], "AWSSecurityHub")
+
+    # If CloudWatch Subscription
+    if "awslogs" in event:
+        data = event["awslogs"]["data"]
+        payload = gzip.decompress(base64.b64decode(data))
+        return deliver(payload, "AWSCloudWatchLog")
+
+    # If application_log
+    if "application_log" in event:
+        log_type = os.environ.get("LOG_TYPE", "ApplicationLog")
+        return deliver(event["application_log"], log_type)
+
+    log.warning(f"Handler received unrecognised event: {event}")
+    return True
+
+
+# v1 (Data Collector API) and v2 (Logs Ingestion API) both live in this layer
+# version. Which one runs is decided per-Lambda by the env vars it carries, so
+# workstream D can move consumers one account at a time rather than all at once.
+# A consumer that sets neither DCE_ENDPOINT nor DCR_CONFIG behaves exactly as it
+# did before.
+def v2_enabled():
+    return bool(os.environ.get("DCE_ENDPOINT")) and bool(os.environ.get("DCR_CONFIG"))
+
+
+def config_present():
+    if v2_enabled():
+        return True
+
     customer_id = os.environ.get("CUSTOMER_ID", False)
-    log_type = os.environ.get("LOG_TYPE", "ApplicationLog")
     shared_key = os.environ.get("SHARED_KEY", False)
 
     if customer_id is False or shared_key is False:
         log.error("customer_id, log_type, or shared_key is missing")
         return False
 
-    # SecurityHub events from EventBridge
-    if "source" in event and event["source"] == "aws.securityhub":
-        line = event["detail"]["findings"]
-        log_type = "AWSSecurityHub"
-        post_data(customer_id, shared_key, json.dumps(line), log_type)
-        return True
-
-    # If CloudWatch Subscription
-    if "awslogs" in event:
-        data = event["awslogs"]["data"]
-        payload = gzip.decompress(base64.b64decode(data))
-        log_type = "AWSCloudWatchLog"
-        post_data(customer_id, shared_key, payload, log_type)
-        return True
-
-    # If application_log
-    if "application_log" in event:
-        line = event["application_log"]
-        post_data(customer_id, shared_key, json.dumps(line), log_type)
-        return True
-
-    log.warning(f"Handler received unrecognised event: {event}")
     return True
+
+
+def deliver(data, log_type):
+    if v2_enabled():
+        return deliver_v2(data, log_type)
+    return deliver_v1(data, log_type)
+
+
+def deliver_v1(data, log_type):
+    customer_id = os.environ.get("CUSTOMER_ID")
+    shared_key = os.environ.get("SHARED_KEY")
+    body = data if isinstance(data, (bytes, bytearray)) else json.dumps(data)
+    post_data(customer_id, shared_key, body, log_type)
+    return True
+
+
+def deliver_v2(data, log_type):
+    target = dcr_target(log_type)
+    if target is None:
+        return False
+
+    records = to_records(data, log_type)
+    if records is None:
+        return False
+
+    client = get_client(os.environ.get("DCE_ENDPOINT"))
+    upload_data(client, target["dcrImmutableId"], target["streamName"], records)
+    return True
+
+
+# DCR_CONFIG maps a log type to the DCR that accepts it, as one JSON env var.
+# Key names come verbatim from the `aws_dcr_config` Terraform output in
+# cds-snc/sentinel; do not rename them here.
+def dcr_target(log_type):
+    try:
+        config = json.loads(os.environ.get("DCR_CONFIG"))
+    except ValueError:
+        log.error("DCR_CONFIG is not valid JSON")
+        return None
+
+    target = config.get(log_type)
+    if not isinstance(target, dict):
+        log.error(f"No DCR_CONFIG entry for log type: {log_type}")
+        return None
+
+    if "dcrImmutableId" not in target or "streamName" not in target:
+        log.error(
+            f"DCR_CONFIG entry for {log_type} is missing dcrImmutableId or streamName"
+        )
+        return None
+
+    return target
+
+
+# The Logs Ingestion API takes a list of records matching the stream's declared
+# columns, not an opaque body. Fields the stream does not declare are dropped at
+# the stream declaration, before the DCR transform runs.
+def to_records(data, log_type):
+    if log_type == "AWSCloudWatchLog":
+        # A CloudWatch envelope has to be split into one record per logEvents[]
+        # entry, because DCR transforms cannot mv-expand. That split is B3.
+        # Refuse until it lands rather than post the envelope whole and lose
+        # every id/timestamp/message as undeclared fields.
+        log.error("CloudWatch v2 delivery needs the sender-side split (B3)")
+        return None
+
+    if isinstance(data, list):
+        return data
+
+    return [data]
+
+
+def get_client(endpoint):
+    global _client
+    if _client is None:
+        _client = create_client(
+            endpoint,
+            client_id=os.environ.get("AZURE_CLIENT_ID"),
+            tenant_id=os.environ.get("AZURE_TENANT_ID"),
+            client_secret=os.environ.get("AZURE_CLIENT_SECRET"),
+        )
+    return _client
+
+
+# Populate the env vars DefaultAzureCredential reads, for the client-secret flow.
+def configure_azure_env(client_id, tenant_id, client_secret):
+    if client_id:
+        os.environ["AZURE_CLIENT_ID"] = client_id
+    if tenant_id:
+        os.environ["AZURE_TENANT_ID"] = tenant_id
+    if client_secret:
+        os.environ["AZURE_CLIENT_SECRET"] = client_secret
+
+
+def cognito_configured():
+    return bool(os.environ.get("COGNITO_IDENTITY_POOL_ID")) and bool(
+        os.environ.get("COGNITO_DEVELOPER_PROVIDER_NAME")
+    )
+
+
+# Mint an OIDC token from Cognito for use as an Entra client assertion. The
+# Lambda's IAM role is the only credential involved; nothing is stored.
+#
+# The developer user identifier is the managed identity's client id, which keeps
+# Cognito's IdentityId mapping deterministic — and that IdentityId is the subject
+# the federated credential matches on.
+def get_cognito_assertion():
+    import boto3
+
+    response = boto3.client(
+        "cognito-identity"
+    ).get_open_id_token_for_developer_identity(
+        IdentityPoolId=os.environ["COGNITO_IDENTITY_POOL_ID"],
+        Logins={
+            os.environ["COGNITO_DEVELOPER_PROVIDER_NAME"]: os.environ["AZURE_CLIENT_ID"]
+        },
+    )
+
+    token = response.get("Token")
+    if not token:
+        raise RuntimeError("Cognito response did not include a Token")
+    return token
+
+
+def create_client(endpoint, client_id=None, tenant_id=None, client_secret=None):
+    # Imported here, not at module scope, and the placement matters.
+    # gc-signin-terraform builds its own layer.zip and rebuilds it by curling
+    # this file alone, without requirements.txt, so its package directory has no
+    # azure-*. A module-level import would raise on their cold start before
+    # v2_enabled() ever runs, breaking them on the v1 path this change is meant
+    # to leave alone. It also keeps the SDK off every v1 consumer's cold start.
+    from azure.identity import ClientAssertionCredential, DefaultAzureCredential
+
+    configure_azure_env(client_id, tenant_id, client_secret)
+
+    # A secret wins when one is present, so a consumer can be moved to v2 with a
+    # secret first and to federation later without a code change.
+    if client_secret:
+        credential = DefaultAzureCredential()
+    elif cognito_configured() and client_id and tenant_id:
+        # The assertion is passed as a callable, never a cached token: a
+        # Cognito token is valid 15 minutes by default while the Entra token
+        # lasts about an hour, so anything minted once at cold start is stale by
+        # the first refresh on a warm container. ClientAssertionCredential
+        # re-invokes func on every refresh, so each one mints a fresh token.
+        credential = ClientAssertionCredential(
+            tenant_id=tenant_id, client_id=client_id, func=get_cognito_assertion
+        )
+        log.info("Authenticating via Cognito federation, no stored secret")
+    else:
+        log.warning(
+            "Neither a client secret nor Cognito federation is configured; "
+            "DefaultAzureCredential will attempt its other credential types"
+        )
+        credential = DefaultAzureCredential()
+
+    from azure.monitor.ingestion import LogsIngestionClient
+
+    return LogsIngestionClient(endpoint=endpoint, credential=credential)
+
+
+def upload_data(client, dcr_immutable_id, stream_name, logs):
+    from azure.core.exceptions import HttpResponseError
+
+    if not logs:
+        log.warning("No data to send to Azure Monitor")
+        return False
+
+    try:
+        # The SDK chunks to the API's 1 MB-per-call limit itself.
+        client.upload(rule_id=dcr_immutable_id, stream_name=stream_name, logs=logs)
+        log.info(f"Uploaded {len(logs)} entries, stream: {stream_name}")
+        return True
+    except HttpResponseError as e:
+        log.error(f"Upload failed: {e}")
+        return False
 
 
 def build_signature(

--- a/layer/requirements.txt
+++ b/layer/requirements.txt
@@ -1,3 +1,5 @@
+azure-identity==1.25.3
+azure-monitor-ingestion==1.1.0
 boto3==1.43.32
 logzero==1.7.0
 requests==2.32.5

--- a/layer/tests/test_connector.py
+++ b/layer/tests/test_connector.py
@@ -1,4 +1,7 @@
+import ast
+import json
 import os
+import pathlib
 import connector
 from unittest.mock import patch
 
@@ -130,3 +133,316 @@ def test_post_data_failure(mock_requests):
     mock_requests.post.return_value.status_code = 400
 
     assert connector.post_data(customer_id, shared_key, body, log_type) is False
+
+
+# --- v2 (Logs Ingestion API) --------------------------------------------------
+
+DCE_ENDPOINT = (
+    "https://dce-sentinel-forwarder-v2-153n.canadacentral-1.ingest.monitor.azure.com"
+)
+
+DCR_CONFIG = json.dumps(
+    {
+        "AWSSecurityHub": {
+            "dcrImmutableId": "dcr-securityhub",
+            "streamName": "Custom-AWSSecurityHub_v2_Input",
+        },
+        "AWSCloudWatchLog": {
+            "dcrImmutableId": "dcr-cloudwatch",
+            "streamName": "Custom-AWSCloudWatchLog_v2_Input",
+        },
+        "ApplicationLog": {
+            "dcrImmutableId": "dcr-application",
+            "streamName": "Custom-ApplicationLog_v2_Input",
+        },
+    }
+)
+
+V2_ENV = {"DCE_ENDPOINT": DCE_ENDPOINT, "DCR_CONFIG": DCR_CONFIG}
+
+CLOUD_WATCH_EVENT = {
+    "awslogs": {
+        "data": "H4sIAAAAAAAAAK2QTWvcMBCG/4oRPS5Y8yGNlFMd6iyBtpSub+lStLE2GNb2xvY2lDT/vbMNvRT21MAgDe+MZh69z6bP85wecvPzmM2V+VA11fdP9WZTrWuzMuPTkCeVLYhEGxEEncqH8WE9jaejVsr0NJeH1O/aVN6M42txs0w59VpFi1gClHrevftYNfWm2e4RwAcPFFrHMYe4T+SSQ/IRiGmnI+bTbr6fuuPSjcNNd1jyNJurO3N+fvt5bbZ/ltQ/8rCc9WfTtbqLBJGsRHJWiNmxQxZg79Fb4hDBWw/BegKHEZkR2LkgpPuWTl1YUq8fAq8YbL11AXD11x0dX7V9NxTVl9tiyo8nbS/WdVNcV1+L/Ti+36XpV5pbjcfX69tgXlb/kvnzWmInjiITUhSHEh0DCgBacqyJU0wQzeIFMk8kb02mRkXPHMiqcd4LCgd0appixhCDiApeXdR+CHCJTJjenCwKiyBbDNaSBoH1apOm0YoEL4BMYiGKgJULZOrv/5JtX34DDTXoyi0DAAA="
+    }
+}
+
+
+def setup_function():
+    # The client is cached for warm-invocation reuse; clear it between tests.
+    connector._client = None
+
+
+# The one regression guard for gc-signin-terraform, which rebuilds its own
+# layer.zip by curling this file without requirements.txt. A module-level azure
+# import raises on their cold start, before v2_enabled() can route them to v1.
+def test_azure_sdk_is_not_imported_at_module_scope():
+    source = pathlib.Path(connector.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+
+    assert not [name for name in imported if name.startswith("azure")]
+
+
+@patch.dict(os.environ, {"CUSTOMER_ID": "foo", "SHARED_KEY": "foo"}, clear=True)
+def test_v2_disabled_without_env_vars():
+    assert connector.v2_enabled() is False
+
+
+@patch.dict(os.environ, {"DCE_ENDPOINT": DCE_ENDPOINT}, clear=True)
+def test_v2_disabled_without_dcr_config():
+    assert connector.v2_enabled() is False
+
+
+@patch.dict(os.environ, {"DCR_CONFIG": DCR_CONFIG}, clear=True)
+def test_v2_disabled_without_dce_endpoint():
+    assert connector.v2_enabled() is False
+
+
+@patch.dict(os.environ, V2_ENV, clear=True)
+def test_v2_enabled_with_both_env_vars():
+    assert connector.v2_enabled() is True
+
+
+# v1 consumers must be untouched by this change: no v2 env vars means the
+# SharedKey sink, even with azure credentials sitting in the environment.
+@patch.dict(
+    os.environ,
+    {"CUSTOMER_ID": "foo", "SHARED_KEY": "foo", "AZURE_CLIENT_ID": "bar"},
+    clear=True,
+)
+@patch("connector.upload_data")
+@patch("connector.post_data")
+def test_v1_still_used_when_v2_env_absent(mock_post_data, mock_upload_data):
+    event = {"source": "aws.securityhub", "detail": {"findings": {"id": "123"}}}
+    assert connector.handle_log(event) is True
+    assert mock_post_data.call_count == 1
+    assert mock_upload_data.call_count == 0
+
+
+# B3 gates its split to v2, so v1 keeps posting the envelope whole and byte-identical.
+@patch.dict(os.environ, {"CUSTOMER_ID": "foo", "SHARED_KEY": "foo"}, clear=True)
+@patch("connector.post_data")
+def test_v1_cloud_watch_posts_the_raw_envelope(mock_post_data):
+    assert connector.handle_log(CLOUD_WATCH_EVENT) is True
+    body = mock_post_data.call_args[0][2]
+    assert isinstance(body, bytes)
+    assert json.loads(body)["logEvents"]
+
+
+@patch.dict(os.environ, V2_ENV, clear=True)
+@patch("connector.get_client")
+@patch("connector.upload_data")
+def test_v2_securityhub_uploads_findings(mock_upload_data, mock_get_client):
+    findings = [{"Id": "finding-1"}, {"Id": "finding-2"}]
+    event = {"source": "aws.securityhub", "detail": {"findings": findings}}
+
+    assert connector.handle_log(event) is True
+    assert mock_upload_data.call_count == 1
+
+    _client, rule_id, stream_name, logs = mock_upload_data.call_args[0]
+    assert rule_id == "dcr-securityhub"
+    assert stream_name == "Custom-AWSSecurityHub_v2_Input"
+    assert logs == findings
+
+
+@patch.dict(os.environ, V2_ENV, clear=True)
+@patch("connector.get_client")
+@patch("connector.upload_data")
+def test_v2_application_log_uploads_one_record(mock_upload_data, mock_get_client):
+    event = {"application_log": {"foo": "bar"}}
+
+    assert connector.handle_log(event) is True
+
+    _client, rule_id, stream_name, logs = mock_upload_data.call_args[0]
+    assert rule_id == "dcr-application"
+    assert stream_name == "Custom-ApplicationLog_v2_Input"
+    assert logs == [{"foo": "bar"}]
+
+
+# Until B3 lands, refusing beats posting an envelope whose logEvents would be
+# dropped as undeclared fields.
+@patch.dict(os.environ, V2_ENV, clear=True)
+@patch("connector.get_client")
+@patch("connector.upload_data")
+def test_v2_cloud_watch_refuses_until_the_split_lands(
+    mock_upload_data, mock_get_client
+):
+    assert connector.handle_log(CLOUD_WATCH_EVENT) is False
+    assert mock_upload_data.call_count == 0
+
+
+@patch.dict(os.environ, V2_ENV, clear=True)
+@patch("connector.get_client")
+@patch("connector.upload_data")
+def test_v2_unmapped_log_type_does_not_upload(mock_upload_data, mock_get_client):
+    with patch.dict(os.environ, {"LOG_TYPE": "NotInTheMap"}):
+        assert connector.handle_log({"application_log": {"foo": "bar"}}) is False
+    assert mock_upload_data.call_count == 0
+
+
+@patch.dict(
+    os.environ,
+    {"DCE_ENDPOINT": DCE_ENDPOINT, "DCR_CONFIG": "not json"},
+    clear=True,
+)
+def test_dcr_target_rejects_invalid_json():
+    assert connector.dcr_target("AWSSecurityHub") is None
+
+
+@patch.dict(
+    os.environ,
+    {
+        "DCE_ENDPOINT": DCE_ENDPOINT,
+        "DCR_CONFIG": json.dumps({"AWSSecurityHub": {"streamName": "Custom-x"}}),
+    },
+    clear=True,
+)
+def test_dcr_target_rejects_incomplete_entry():
+    assert connector.dcr_target("AWSSecurityHub") is None
+
+
+@patch.dict(os.environ, V2_ENV, clear=True)
+def test_dcr_target_returns_both_fields():
+    target = connector.dcr_target("AWSCloudWatchLog")
+    assert target["dcrImmutableId"] == "dcr-cloudwatch"
+    assert target["streamName"] == "Custom-AWSCloudWatchLog_v2_Input"
+
+
+@patch.dict(os.environ, V2_ENV, clear=True)
+@patch("connector.create_client")
+def test_get_client_is_cached_across_invocations(mock_create_client):
+    first = connector.get_client(DCE_ENDPOINT)
+    second = connector.get_client(DCE_ENDPOINT)
+    assert first is second
+    assert mock_create_client.call_count == 1
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_configure_azure_env_sets_client_secret_variables():
+    connector.configure_azure_env("client", "tenant", "secret")
+    assert os.environ["AZURE_CLIENT_ID"] == "client"
+    assert os.environ["AZURE_TENANT_ID"] == "tenant"
+    assert os.environ["AZURE_CLIENT_SECRET"] == "secret"
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_configure_azure_env_without_secret_sets_no_secret():
+    connector.configure_azure_env("client", "tenant", None)
+    assert "AZURE_CLIENT_SECRET" not in os.environ
+
+
+COGNITO_ENV = {
+    "AZURE_CLIENT_ID": "client",
+    "AZURE_TENANT_ID": "tenant",
+    "COGNITO_IDENTITY_POOL_ID": "ca-central-1:00000000-0000-0000-0000-000000000000",
+    "COGNITO_DEVELOPER_PROVIDER_NAME": "azure-sentinel-access",
+}
+
+
+# A secret wins when present, so a consumer can move to v2 with a secret first
+# and to federation later without a code change.
+@patch.dict(os.environ, dict(COGNITO_ENV, AZURE_CLIENT_SECRET="s"), clear=True)
+@patch("azure.monitor.ingestion.LogsIngestionClient")
+@patch("azure.identity.ClientAssertionCredential")
+@patch("azure.identity.DefaultAzureCredential")
+def test_create_client_prefers_the_secret(mock_default, mock_assertion, mock_lic):
+    connector.create_client(DCE_ENDPOINT, "client", "tenant", "s")
+    assert mock_default.call_count == 1
+    assert mock_assertion.call_count == 0
+
+
+@patch.dict(os.environ, COGNITO_ENV, clear=True)
+@patch("azure.monitor.ingestion.LogsIngestionClient")
+@patch("azure.identity.ClientAssertionCredential")
+@patch("azure.identity.DefaultAzureCredential")
+def test_create_client_federates_when_no_secret(mock_default, mock_assertion, mock_lic):
+    connector.create_client(DCE_ENDPOINT, "client", "tenant", None)
+    assert mock_assertion.call_count == 1
+    assert mock_default.call_count == 0
+
+    kwargs = mock_assertion.call_args[1]
+    assert kwargs["tenant_id"] == "tenant"
+    assert kwargs["client_id"] == "client"
+    # The callable, not a token: it is re-invoked on every refresh, so a Cognito
+    # token minted at cold start cannot go stale on a warm container.
+    assert kwargs["func"] is connector.get_cognito_assertion
+
+
+@patch.dict(os.environ, {"AZURE_CLIENT_ID": "client"}, clear=True)
+@patch("azure.monitor.ingestion.LogsIngestionClient")
+@patch("azure.identity.ClientAssertionCredential")
+@patch("azure.identity.DefaultAzureCredential")
+def test_create_client_falls_back_with_neither(mock_default, mock_assertion, mock_lic):
+    connector.create_client(DCE_ENDPOINT, "client", None, None)
+    assert mock_default.call_count == 1
+    assert mock_assertion.call_count == 0
+
+
+@patch.dict(os.environ, COGNITO_ENV, clear=True)
+def test_get_cognito_assertion_returns_the_token():
+    with patch("boto3.client") as mock_boto:
+        mock_boto.return_value.get_open_id_token_for_developer_identity.return_value = {
+            "Token": "the-jwt"
+        }
+        assert connector.get_cognito_assertion() == "the-jwt"
+
+    call = mock_boto.return_value.get_open_id_token_for_developer_identity.call_args[1]
+    assert call["IdentityPoolId"] == COGNITO_ENV["COGNITO_IDENTITY_POOL_ID"]
+    # The developer user identifier is the managed identity's client id, which
+    # keeps Cognito's IdentityId — the federated credential's subject — stable.
+    assert call["Logins"] == {"azure-sentinel-access": "client"}
+
+
+@patch.dict(os.environ, COGNITO_ENV, clear=True)
+def test_get_cognito_assertion_raises_without_a_token():
+    with patch("boto3.client") as mock_boto:
+        mock_boto.return_value.get_open_id_token_for_developer_identity.return_value = (
+            {}
+        )
+        try:
+            connector.get_cognito_assertion()
+            assert False, "expected RuntimeError"
+        except RuntimeError:
+            pass
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_cognito_not_configured_without_env():
+    assert connector.cognito_configured() is False
+
+
+@patch.dict(os.environ, COGNITO_ENV, clear=True)
+def test_cognito_configured_with_env():
+    assert connector.cognito_configured() is True
+
+
+def test_upload_data_success():
+    client = patch("connector.get_client").start()
+    client.upload.return_value = None
+    assert connector.upload_data(client, "dcr-1", "Custom-x", [{"a": 1}]) is True
+    client.upload.assert_called_once_with(
+        rule_id="dcr-1", stream_name="Custom-x", logs=[{"a": 1}]
+    )
+    patch.stopall()
+
+
+def test_upload_data_with_no_records():
+    client = patch("connector.get_client").start()
+    assert connector.upload_data(client, "dcr-1", "Custom-x", []) is False
+    assert client.upload.call_count == 0
+    patch.stopall()
+
+
+def test_upload_data_failure():
+    from azure.core.exceptions import HttpResponseError
+
+    client = patch("connector.get_client").start()
+    client.upload.side_effect = HttpResponseError("rejected")
+    assert connector.upload_data(client, "dcr-1", "Custom-x", [{"a": 1}]) is False
+    patch.stopall()


### PR DESCRIPTION
## Summary

This PR adds the Logs Ingestion API (DCE/DCR) processing and keeps the v1 backward compatible. 

Second of six commits in Phase 2 workstream B. B1 (dead S3 parsers) shipped as layer version 263.

### What changed

- `handle_log()` routes every branch through `deliver()`, which selects the sink. `post_data()` and `build_signature()` are untouched.
- `DCR_CONFIG` maps a log type to `{ dcrImmutableId, streamName }`, consuming the `aws_dcr_config` Terraform output key names verbatim.
- Auth supports two flows, selected by variable presence, with **a client secret winning when one is present** so a consumer can move to v2 with a secret first and to federation later without a code change:

  | | Client secret | Cognito federation |
  | --- | --- | --- |
  | Variables | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `COGNITO_IDENTITY_POOL_ID`, `COGNITO_DEVELOPER_PROVIDER_NAME` |
  | Credential | `DefaultAzureCredential` | `ClientAssertionCredential` |

  The managed identity for the federated flow is in cds-snc/cds-azure-resources.
- `azure-identity` and `azure-monitor-ingestion` added to `requirements.txt`.
